### PR TITLE
Further implementation of busMoved.

### DIFF
--- a/SAVSimulator/src/application/Main.java
+++ b/SAVSimulator/src/application/Main.java
@@ -43,9 +43,14 @@ public class Main extends Application {
 			
 			
 			
-			cityDisplay.addPerson(3, 0);
+//			cityDisplay.addPerson(3, 0);
+//			cityDisplay.removePerson(3, 0);
+			
+			cityDisplay.busArrived(0, 0);
 			cityDisplay.busArrived(0, 0);
 			cityDisplay.busMoved(0, 0, 4, 5);
+			cityDisplay.busArrived(4, 5);
+			cityDisplay.busMoved(4, 5, 11, 12);
 			
 			// Create City object, then run simulation.
 


### PR DESCRIPTION
Added storage of current bus counts by intersection to CityDisplay. Converted code to use FadeTransition instead of setVisibility. FUNDAMENTAL PROBLEM: Buses should not be one per intersection. While people and intersections stay in one place, buses should have one instance per actual bus equivalent in City class. This would work much better when compared to having one bus marker per intersection and making it visible/invisible when necessary.