### PR TITLE
Have program exit when non-display simulation is complete.

### DIFF
--- a/SAVSimulator/src/application/Main.java
+++ b/SAVSimulator/src/application/Main.java
@@ -15,6 +15,9 @@ public class Main extends Application {
 
 	@Override
 	public void start(Stage primaryStage) {
+		
+		// Parameters: display? algorithm
+		
 		Parameters params = getParameters();
 		List<String> paramsList = params.getRaw();
 		
@@ -105,6 +108,7 @@ public class Main extends Application {
 				}
 				
 				System.out.println("AVERAGE STEP COUNT: " + (stepSum / count));
+				System.exit(0);
 			}
 
 		} catch (Exception e) {


### PR DESCRIPTION
Otherwise, in the past, CTRL+C (or alternative) was required to exit.